### PR TITLE
Allow renaming states

### DIFF
--- a/css/fsm.css
+++ b/css/fsm.css
@@ -91,7 +91,8 @@ h5 {
 
   div.state {
     position: absolute;
-    width: 100px;
+    display: flex;
+    min-width: 100px;
     height: 30px;
     line-height: 30px;
     background-color: #add;
@@ -110,26 +111,36 @@ h5 {
     }
 
     div.plumbSource {
-      position: absolute;
+      position: relative;
+      display: inline-block;
       width: 20px;
       height: 20px;
-      right: 5px;
+      margin: 0 5px;
       top: 5px;
       background-color: #55a;
       cursor: pointer;
       border-radius: 6px;
     }
 
+    span.stateName {
+      flex-grow: 1;
+    }
+
     input[type="checkbox"].isAccept {
-      position: absolute;
-      top: 5px;
-      left: 5px;
+      margin: 5px;
+      height: 20px;
     }
 
     div.state div.delete {
       position: absolute;
+      left: 0;
+      width: 100%;
+      height: 0;
+    }
+    div.state img.delete {
+      position: relative;
       top: -18px;
-      left: 40px;
+      cursor: pointer;
     }
 
 div.delete {
@@ -139,10 +150,6 @@ div.delete {
   text-align: center;
   color: #aaa;
   z-index: 100;
-}
-
-div.delete:hover {
-  cursor: pointer;
 }
 
 #fsmDebugInputStatus {


### PR DESCRIPTION
Setting meaningful names for states greatly helps understanding what the automaton does. This commit allows the user to set display names for the states (the internal ID being the default), while keeping the internal IDs intact. It also adjusts the layout to account for longer user-defined names: the states may be wider than 100px if needed (but never narrower). It uses flexbox, which has [pretty good browser support](https://caniuse.com/flexbox), and degrades gracefully even in browsers not supporting it.